### PR TITLE
Address multiple security vulnerabilities

### DIFF
--- a/core/import_users_api.php
+++ b/core/import_users_api.php
@@ -35,7 +35,8 @@ function read_csv_file( $p_filename ) {
 
 # --------------------
 function read_csv_row( $p_file_row, $p_separator ) {
-	$t_regexp = '/\G(?:\A|\\' . $p_separator . ')([^"\\' . $p_separator . ']+|(?:"[^"]*")*)/sm';
+	$t_q_sep = preg_quote( $p_separator, '/' );
+	$t_regexp = '/\G(?:\A|' . $t_q_sep . ')([^"' . $t_q_sep . ']+|(?:"[^"]*")*)/sm';
 	preg_match_all( $t_regexp, $p_file_row, $t_row_element );
 	return array_map( 'csv_string_unescape', $t_row_element[1] );
 }

--- a/pages/import_users.php
+++ b/pages/import_users.php
@@ -13,6 +13,8 @@ require_api( 'bug_api.php' );
 plugin_require_api( 'core/import_users_api.php' );
 access_ensure_project_level( ADMINISTRATOR );
 
+form_security_validate( 'plugin_import_users_col_set' );
+
 layout_page_header( plugin_lang_get( 'import_users' ) );
 layout_page_begin();
 
@@ -20,7 +22,21 @@ $f_import_file = gpc_get_string( 'import_file' );
 $f_separator = gpc_get_string( 'edt_cell_separator' );
 $f_column_count = gpc_get_string( 'import_column_count' ) + 1;
 $f_invite_emails = gpc_get_bool( 'invite_emails' );
-$t_file_content = read_csv_file( $f_import_file );
+
+# Validate the import file path is within the PHP temp directory to prevent path traversal.
+# Use upload_tmp_dir when set (it can differ from sys_get_temp_dir on some configurations).
+# stripos gives case-insensitive comparison needed on Windows; DIRECTORY_SEPARATOR prevents
+# a path like /tmpEvil from matching a prefix of /tmp.
+$t_upload_tmp_dir = ini_get( 'upload_tmp_dir' );
+$t_temp_dir = realpath( is_blank( $t_upload_tmp_dir ) ? sys_get_temp_dir() : $t_upload_tmp_dir );
+$t_real_import_file = realpath( $f_import_file );
+if( $t_temp_dir === false
+	|| $t_real_import_file === false
+	|| stripos( $t_real_import_file, $t_temp_dir . DIRECTORY_SEPARATOR ) !== 0 ) {
+	trigger_error( ERROR_ACCESS_DENIED, ERROR );
+}
+
+$t_file_content = read_csv_file( $t_real_import_file );
 
 $t_columns_lables = array();
 $users_info = array();
@@ -31,7 +47,6 @@ $t_first_run = true;
 # Import status
 $status = array();
 
-error_reporting( 0 );
 $error_message = array();
 
 foreach( $t_file_content as &$t_file_line ) {

--- a/pages/import_users.php
+++ b/pages/import_users.php
@@ -14,6 +14,7 @@ plugin_require_api( 'core/import_users_api.php' );
 access_ensure_project_level( ADMINISTRATOR );
 
 form_security_validate( 'plugin_import_users_col_set' );
+form_security_purge( 'plugin_import_users_col_set' );
 
 layout_page_header( plugin_lang_get( 'import_users' ) );
 layout_page_begin();

--- a/pages/import_users.php
+++ b/pages/import_users.php
@@ -14,7 +14,6 @@ plugin_require_api( 'core/import_users_api.php' );
 access_ensure_project_level( ADMINISTRATOR );
 
 form_security_validate( 'plugin_import_users_col_set' );
-form_security_purge( 'plugin_import_users_col_set' );
 
 layout_page_header( plugin_lang_get( 'import_users' ) );
 layout_page_begin();
@@ -117,6 +116,8 @@ foreach( $t_file_content as &$t_file_line ) {
 		}
 	}
 }
+
+form_security_purge( 'plugin_import_users_col_set' );
 ?>
 
 <div class="col-md-12 col-xs-12">

--- a/pages/import_users_page_col_set.php
+++ b/pages/import_users_page_col_set.php
@@ -9,6 +9,8 @@ plugin_require_api( 'core/import_users_api.php' );
 
 access_ensure_global_level( ADMINISTRATOR );
 
+form_security_validate( 'plugin_import_users' );
+
 layout_page_header( plugin_lang_get( 'import_users' ) );
 layout_page_begin();
 
@@ -82,7 +84,7 @@ move_uploaded_file( $f_import_file ['tmp_name'], $t_file_name );
 	<div class="widget-box widget-color-blue2">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">
-				<?php echo $f_import_file['name']?>	
+				<?php echo string_html_specialchars( $f_import_file['name'] )?>
 		    </h4>
 		</div>
 
@@ -174,8 +176,9 @@ foreach ( $t_file_content as &$t_file_line ) {
 
 			<div class="widget-toolbox padding-8 clearfix">
 			<form method="post" action="<?php echo $t_import_it ?>">
-				<input type="hidden" name="edt_cell_separator" value="<?php echo $t_separator ?>" /> 
-				<input type="hidden" name="import_file" value="<?php echo $t_file_name ?>" /> 
+				<?php echo form_security_field( 'plugin_import_users_col_set' ) ?>
+				<input type="hidden" name="edt_cell_separator" value="<?php echo string_html_specialchars( $t_separator ) ?>" /> 
+				<input type="hidden" name="import_file" value="<?php echo string_html_specialchars( $t_file_name ) ?>" /> 
 				<input type="hidden" name="import_column_count" value="<?php echo $t_column_count ?>" /> 
 				<input type="hidden" name="invite_emails" value="<?php echo $f_invite_emails ?>" /> 
 				<input type="submit" id="importForm" class="btn btn-primary btn-white btn-sm btn-round" value="<?php echo plugin_lang_get( 'file_button' ) ?>" />

--- a/pages/import_users_page_col_set.php
+++ b/pages/import_users_page_col_set.php
@@ -10,6 +10,7 @@ plugin_require_api( 'core/import_users_api.php' );
 access_ensure_global_level( ADMINISTRATOR );
 
 form_security_validate( 'plugin_import_users' );
+form_security_purge( 'plugin_import_users' );
 
 layout_page_header( plugin_lang_get( 'import_users' ) );
 layout_page_begin();

--- a/pages/import_users_page_col_set.php
+++ b/pages/import_users_page_col_set.php
@@ -10,7 +10,6 @@ plugin_require_api( 'core/import_users_api.php' );
 access_ensure_global_level( ADMINISTRATOR );
 
 form_security_validate( 'plugin_import_users' );
-form_security_purge( 'plugin_import_users' );
 
 layout_page_header( plugin_lang_get( 'import_users' ) );
 layout_page_begin();
@@ -74,6 +73,8 @@ if( is_writable( $f_import_file ['tmp_name'] ) ) {
 // Move file
 $t_file_name = tempnam( dirname ( $f_import_file ['tmp_name'] ), 'tmp' );
 move_uploaded_file( $f_import_file ['tmp_name'], $t_file_name );
+
+form_security_purge( 'plugin_import_users' );
 ?>
 
 <!-- File extraction -->

--- a/pages/import_users_page_init.php
+++ b/pages/import_users_page_init.php
@@ -21,6 +21,7 @@ $t_max_file_size = (int)min( ini_get_number( 'upload_max_filesize' ), ini_get_nu
 	<div class="space-10"></div>
 	<div class="form-container">
 		<form method="post" enctype="multipart/form-data" action="<?php echo $t_import_page ?>">
+			<?php echo form_security_field( 'plugin_import_users' ) ?>
 
 		<div class="widget-box widget-color-blue2">
 			<div class="widget-header widget-header-small">


### PR DESCRIPTION
[Task](https://tasks.mantishub.io/app/issues/23324)

This PR fixes multiple security vulnerabilities identified during a security review.

### Fixes

* **Path traversal**
  Validates the user-supplied import file path using `realpath()` and rejects the request with `ERROR_ACCESS_DENIED` unless the resolved path is within the PHP upload temp directory (`upload_tmp_dir` / `sys_get_temp_dir()`).
  The comparison is case-insensitive and enforces a trailing directory separator to prevent prefix-matching bypasses.

* **Missing CSRF protection**
  Adds `form_security_field()` to upload forms and `form_security_validate()` to processing pages to protect against CSRF attacks.

* **XSS — unescaped filename**
  Escapes uploaded filename output using `string_html_specialchars()` before rendering.

* **Regex injection via separator**
  Applies `preg_quote()` to the CSV separator before using it in a regex pattern.

* **Unescaped hidden form values**
  Escapes hidden form field values using `string_html_specialchars()`.

* **Error suppression removed**
  Removes `error_reporting(0)` to restore proper PHP error visibility.

