### PR TITLE
Replace deprecated utf8_encode() with mb_convert_encoding()

### DIFF
--- a/core/import_users_api.php
+++ b/core/import_users_api.php
@@ -43,7 +43,7 @@ function read_csv_row( $p_file_row, $p_separator ) {
 
 # --------------------
 function prepare_output( $p_string ) {
-	return string_html_specialchars( utf8_encode( $p_string ) );
+	return string_html_specialchars( mb_convert_encoding( $p_string, 'UTF-8', 'ISO-8859-1' ) );
 }
 
 # --------------------


### PR DESCRIPTION
[Task](https://tasks.mantishub.io/app/issues/23030)
[Task](https://tasks.mantishub.io/app/issues/23031)

## Summary
- Replace the deprecated `utf8_encode()` call in `prepare_output()` with `mb_convert_encoding($p_string, 'UTF-8', 'ISO-8859-1')`.
- Restores behavior parity (ISO-8859-1 -> UTF-8) without triggering PHP 8.2 deprecation notices.
- Requires the `mbstring` extension (standard on most MantisBT installs).

## Why
`utf8_encode()` is deprecated as of PHP 8.2 and slated for removal in a future major version. CSV uploads that include non-ASCII characters were emitting deprecation warnings on each row in `prepare_output()`. `mb_convert_encoding()` with explicit source/target charsets is the documented replacement and matches the original semantics exactly (only ISO-8859-1 input was ever supported by `utf8_encode`).

Related PRs:
https://github.com/mantishub/mantishub/pull/261
https://github.com/mantishub/ApiX/pull/400
https://github.com/mantishub/pages/pull/40
https://github.com/mantishub/csv-import/pull/2
https://github.com/mantishub/dantis/pull/35
https://github.com/mantishub/slack/pull/15
https://github.com/mantishub/slack/pull/14
https://github.com/mantishub/slack/pull/16
https://github.com/mantishub/livelinks/pull/5
https://github.com/mantishub/RecurringTasks/pull/86
https://github.com/mantisbt-plugins/EventLog/pull/10
https://github.com/mantisbt-plugins/source-integration/pull/433
